### PR TITLE
fix various naming issues

### DIFF
--- a/scripts/aa_babele.js
+++ b/scripts/aa_babele.js
@@ -1,15 +1,17 @@
-Hooks.on("aa.getRequiredData", (data) => {    
+const capitalize = (str, lower = false) =>
+  (lower ? str.toLowerCase() : str).replace(/(?:^|\s|["'([{])+\S/g, match => match.toUpperCase());
+;
+
+Hooks.on("aa.getRequiredData", (data) => {
     console.log("aa.getRequiredData hook fired", data);
     let originalName = getProperty(data.item, "flags.babele.originalName");
 
     if (!originalName) {
         originalName = getProperty(data.item, "system.identifier");
-        originalName = originalName.replaceAll("-", " ");
+        originalName = capitalize(originalName.replaceAll("-", " "));
     }
 
     if (!originalName) return;
 
     data.overrideNames.push(originalName);
-    // data.overrideNames = [originalName];   
-    data.item.name = originalName;
 });


### PR DESCRIPTION
Some names would still not work as they are capitalized in AA but are not if based onto the system.identifier (ex: fireball vs Fireball in AA)

Also, overriding data.item.name changes the item name in the player's sheet, replacing it with the identifier, so I've removed that